### PR TITLE
Add option to convert download links to osu!direct

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Userscript adding osu! related functionality to /r/osugame
 * Displays player name and pp/rank on flair hover
 * Adds live twitch streams to the sidebar
 * Adds song preview buttons to beatmap links
+* Converts beatmap download links to osu!direct download links
 
 ## Screenshots
 ![flairs](http://i.imgur.com/vqFPUPK.png) ![streams](http://i.imgur.com/VWOJuwr.png)

--- a/osugame_func+.user.js
+++ b/osugame_func+.user.js
@@ -66,6 +66,12 @@ function setupConfig() {
                 "default": true
             },
 
+            "osudirect": {
+                "label": "Convert beatmap download links to osu!direct downloads",
+                "type": "checkbox",
+                "default": false
+            },
+
             "parallax": {
                 "label": "Parallax effect in header",
                 "type": "checkbox",
@@ -87,6 +93,7 @@ function setupConfig() {
     g_refreshstreams = GM_config.get("refreshstreams");
     g_refreshrate = GM_config.get("refreshrate");
     g_songs = GM_config.get("songs");
+    g_osudirect = GM_config.get("osudirect");
     g_parallax = GM_config.get("parallax");
     g_debug = GM_config.get("debug");
 
@@ -412,6 +419,19 @@ function Osulinkbox() {
     }
 }
 
+function Osudirectbox() {
+    var entries = document.getElementsByClassName("usertext-body");
+    for(let i=entries.length-1; i>=0; i--) {
+        var links = entries[i].getElementsByTagName("a");
+
+        for(let j=links.length-1; j>=0; j--) {
+            if( links[j].href.search("^https?://osu\.ppy\.sh/d/") !== -1 ) {
+                links[j].href = links[j].href.replace(/^https?:\/\/osu\.ppy\.sh\/d\//, "osu://dl/");
+            }
+        }
+    }
+}
+
 var pippy, srheader, navtop;
 function parallax() {
     pippy.style["background-position"] = "0 58px, 0 "+
@@ -433,6 +453,10 @@ window.addEventListener("load", function(){
 
     if(g_songs) {
         Osulinkbox();
+    }
+
+    if(g_osudirect) {
+        Osudirectbox();
     }
 
     Flairbox();


### PR DESCRIPTION
After commit mcpower/beatmaplinker@0a1b53a29b99f7449a20c41b630a61f7d3cdd26f, BeatmapLinker now has download links to maps. However, it is impossible to link to an osu!direct link on reddit due to the restrictions it has on URI schemes. If a user has osu!direct and wishes to download maps directly from a comment, they can use this option to do that.

Note that the version number has not been incremented, ~~and this commit has not been fully tested~~.
